### PR TITLE
Fix `feature/stable-cadence` tests & `main` branch CI trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - master
-      - 'feature/**'
+      - feature/**
   pull_request:
     branches:
       - master
-      - 'feature/**'
+      - feature/**
 
 env:
   GO_VERSION: '1.20'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - master
-      - feature/**
+      - 'feature/**'
   pull_request:
     branches:
       - master
-      - feature/**
+      - 'feature/**'
 
 env:
   GO_VERSION: '1.20'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,11 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
       - 'feature/**'
   pull_request:
     branches:
-      - master
+      - main
       - 'feature/**'
 
 env:

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -325,11 +325,12 @@ func Test_DefaultConfig(t *testing.T) {
 	assert.Len(t, cfg.Emulators, 1)
 	assert.Equal(t, "default", cfg.Emulators[0].Name)
 	assert.Equal(t, "emulator-account", cfg.Emulators[0].ServiceAccount)
-	assert.Len(t, cfg.Networks, 4)
+	assert.Len(t, cfg.Networks, 5)
 	assert.Equal(t, "emulator", cfg.Networks[0].Name)
 	assert.Equal(t, "testing", cfg.Networks[1].Name)
 	assert.Equal(t, "testnet", cfg.Networks[2].Name)
 	assert.Equal(t, "mainnet", cfg.Networks[3].Name)
+	assert.Equal(t, "previewnet", cfg.Networks[4].Name)
 }
 
 func Test_DefaultPath(t *testing.T) {


### PR DESCRIPTION
Looks like tests are failing from https://github.com/onflow/flowkit/pull/18.

CI didn't trigger because branch was initially targetting `main`, but CI doesn't trigger for main 🙃