### PR TITLE
Contract deployment args fix

### DIFF
--- a/config/json/deploy.go
+++ b/config/json/deploy.go
@@ -20,7 +20,6 @@ package json
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/invopop/jsonschema"
 	"github.com/onflow/cadence"
@@ -103,18 +102,7 @@ func transformDeploymentsToJSON(configDeployments config.Deployments) jsonDeploy
 			} else {
 				args := make([]map[string]any, 0)
 				for _, arg := range c.Args {
-					switch arg.Type().ID() {
-					case "Bool":
-						args = append(args, map[string]any{
-							"type":  arg.Type().ID(),
-							"value": arg.ToGoValue(),
-						})
-					default:
-						args = append(args, map[string]any{
-							"type":  arg.Type().ID(),
-							"value": fmt.Sprintf("%v", arg.ToGoValue()),
-						})
-					}
+					args = append(args, jsoncdc.Prepare(arg).(map[string]any))
 				}
 
 				deployments = append(deployments, deployment{

--- a/config/json/deploy.go
+++ b/config/json/deploy.go
@@ -100,9 +100,9 @@ func transformDeploymentsToJSON(configDeployments config.Deployments) jsonDeploy
 					simple: c.Name,
 				})
 			} else {
-				args := make([]map[string]any, 0)
+				args := make([]any, 0)
 				for _, arg := range c.Args {
-					args = append(args, jsoncdc.Prepare(arg).(map[string]any))
+					args = append(args, jsoncdc.Prepare(arg))
 				}
 
 				deployments = append(deployments, deployment{
@@ -128,8 +128,8 @@ func transformDeploymentsToJSON(configDeployments config.Deployments) jsonDeploy
 }
 
 type contractDeployment struct {
-	Name string           `json:"name"`
-	Args []map[string]any `json:"args"`
+	Name string `json:"name"`
+	Args []any  `json:"args"`
 }
 
 type deployment struct {

--- a/config/json/deploy_test.go
+++ b/config/json/deploy_test.go
@@ -102,17 +102,23 @@ func Test_TransformDeployToJSON(t *testing.T) {
 		}
 	}`)
 
-	var jsonDeployments jsonDeployments
-	err := json.Unmarshal(b, &jsonDeployments)
+	var original jsonDeployments
+	err := json.Unmarshal(b, &original)
 	assert.NoError(t, err)
 
-	deployments, err := jsonDeployments.transformToConfig()
+	deployments, err := original.transformToConfig()
 	assert.NoError(t, err)
 
 	j := transformDeploymentsToJSON(deployments)
 	x, _ := json.Marshal(j)
 
-	assert.Equal(t, cleanSpecialChars(b), cleanSpecialChars(x))
+	// Unmarshal the config again to compare against the original
+	var result jsonDeployments
+	err = json.Unmarshal(x, &result)
+	assert.NoError(t, err)
+
+	// Check that result is same as original after transformation
+	assert.Equal(t, original, result)
 }
 
 func Test_DeploymentAdvanced(t *testing.T) {

--- a/schema.json
+++ b/schema.json
@@ -120,9 +120,7 @@
           "type": "string"
         },
         "args": {
-          "items": {
-            "type": "object"
-          },
+          "items": true,
           "type": "array"
         }
       },


### PR DESCRIPTION
solves https://github.com/onflow/flow-cli/issues/1352 & https://github.com/onflow/flow-cli/issues/1254

Mostly a backport of the changes made in https://github.com/onflow/flowkit/compare/dc655f4...a1765cd on the `stable-cadence` branch.

Forced changes that were necessary to update to latest Cadence version unintentionally fixed this issue

That being said, it uses the `Prepare` function instead of marshalling and unmarshalling as a hack to convert structs to `map[string]any` which is a better/simpler way to fix this.  Because the JSON values from Cadence are structs, we cannot conform to `map[string]any`, so I relaxed the deployment arg type to `any`