### PR TITLE
Add CODECOV_TOKEN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           file: ./coverage.txt
           flags: unittests
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
New changes to codecov make it unusable without a token.  Causes CI to hang, so we need to merge this PR & @bthaile can add the token to this repo.