### PR TITLE
Add support for `block_height` pins for dependencies

### DIFF
--- a/config/dependency.go
+++ b/config/dependency.go
@@ -49,11 +49,12 @@ type Source struct {
 }
 
 type Dependency struct {
-	Name      string
-	Source    Source
-	Hash      string
-	Aliases   Aliases
-	Canonical string
+	Name        string
+	Source      Source
+	Hash        string
+	BlockHeight uint64
+	Aliases     Aliases
+	Canonical   string
 }
 
 type Dependencies []Dependency

--- a/config/json/dependency.go
+++ b/config/json/dependency.go
@@ -59,9 +59,10 @@ func (j jsonDependencies) transformToConfig() (config.Dependencies, error) {
 			}
 
 			dep = config.Dependency{
-				Name:      dependencyName,
-				Hash:      dependency.Extended.Hash,
-				Canonical: dependency.Extended.Canonical,
+				Name:        dependencyName,
+				Hash:        dependency.Extended.Hash,
+				BlockHeight: dependency.Extended.BlockHeight,
+				Canonical:   dependency.Extended.Canonical,
 				Source: config.Source{
 					NetworkName:  depNetwork,
 					Address:      flow.HexToAddress(depAddress),
@@ -100,10 +101,11 @@ func transformDependenciesToJSON(configDependencies config.Dependencies, configC
 
 		jsonDeps[dep.Name] = jsonDependency{
 			Extended: jsonDependencyExtended{
-				Source:    buildSourceString(dep.Source),
-				Hash:      dep.Hash,
-				Aliases:   aliases,
-				Canonical: dep.Canonical,
+				Source:      buildSourceString(dep.Source),
+				Hash:        dep.Hash,
+				BlockHeight: dep.BlockHeight,
+				Aliases:     aliases,
+				Canonical:   dep.Canonical,
 			},
 		}
 	}
@@ -125,10 +127,11 @@ func buildSourceString(source config.Source) string {
 
 // jsonDependencyExtended for json parsing advanced config.
 type jsonDependencyExtended struct {
-	Source    string            `json:"source"`
-	Hash      string            `json:"hash"`
-	Aliases   map[string]string `json:"aliases"`
-	Canonical string            `json:"canonical,omitempty"`
+	Source      string            `json:"source"`
+	Hash        string            `json:"hash"`
+	BlockHeight uint64            `json:"block_height,omitempty"`
+	Aliases     map[string]string `json:"aliases"`
+	Canonical   string            `json:"canonical,omitempty"`
 }
 
 // jsonDependency structure for json parsing.

--- a/gateway/emulator.go
+++ b/gateway/emulator.go
@@ -111,6 +111,15 @@ func (g *EmulatorGateway) GetAccount(ctx context.Context, address flow.Address) 
 	return account, nil
 }
 
+func (g *EmulatorGateway) GetAccountAtBlockHeight(ctx context.Context, address flow.Address, blockHeight uint64) (*flow.Account, error) {
+	account, err := g.adapter.GetAccountAtBlockHeight(ctx, address, blockHeight)
+	if err != nil {
+		return nil, UnwrapStatusError(err)
+	}
+	return account, nil
+}
+
+
 func (g *EmulatorGateway) SendSignedTransaction(ctx context.Context, tx *flow.Transaction) (*flow.Transaction, error) {
 	err := g.adapter.SendTransaction(ctx, *tx)
 	if err != nil {

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -30,6 +30,7 @@ import (
 // Gateway describes blockchain access interface
 type Gateway interface {
 	GetAccount(context.Context, flow.Address) (*flow.Account, error)
+	GetAccountAtBlockHeight(context.Context, flow.Address, uint64) (*flow.Account, error)
 	SendSignedTransaction(context.Context, *flow.Transaction) (*flow.Transaction, error)
 	GetTransaction(context.Context, flow.Identifier) (*flow.Transaction, error)
 	GetTransactionResultsByBlockID(ctx context.Context, blockID flow.Identifier) ([]*flow.TransactionResult, error)

--- a/gateway/grpc.go
+++ b/gateway/grpc.go
@@ -109,6 +109,17 @@ func (g *GrpcGateway) GetAccount(ctx context.Context, address flow.Address) (*fl
 	return account, nil
 }
 
+// GetAccountAtBlockHeight gets an account by address at a specific block height from the Flow Access API.
+func (g *GrpcGateway) GetAccountAtBlockHeight(ctx context.Context, address flow.Address, blockHeight uint64) (*flow.Account, error) {
+	account, err := g.client.GetAccountAtBlockHeight(ctx, address, blockHeight)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get account with address %s at block height %d: %w", address, blockHeight, err)
+	}
+
+	return account, nil
+}
+
+
 // SendSignedTransaction sends a transaction to flow that is already prepared and signed.
 func (g *GrpcGateway) SendSignedTransaction(ctx context.Context, tx *flow.Transaction) (*flow.Transaction, error) {
 	err := g.client.SendTransaction(ctx, *tx)

--- a/gateway/mocks/Gateway.go
+++ b/gateway/mocks/Gateway.go
@@ -137,6 +137,36 @@ func (_m *Gateway) GetAccount(_a0 context.Context, _a1 flow.Address) (*flow.Acco
 	return r0, r1
 }
 
+// GetAccountAtBlockHeight provides a mock function with given fields: _a0, _a1, _a2
+func (_m *Gateway) GetAccountAtBlockHeight(_a0 context.Context, _a1 flow.Address, _a2 uint64) (*flow.Account, error) {
+	ret := _m.Called(_a0, _a1, _a2)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAccountAtBlockHeight")
+	}
+
+	var r0 *flow.Account
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, flow.Address, uint64) (*flow.Account, error)); ok {
+		return rf(_a0, _a1, _a2)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, flow.Address, uint64) *flow.Account); ok {
+		r0 = rf(_a0, _a1, _a2)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*flow.Account)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, flow.Address, uint64) error); ok {
+		r1 = rf(_a0, _a1, _a2)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetBlockByHeight provides a mock function with given fields: _a0, _a1
 func (_m *Gateway) GetBlockByHeight(_a0 context.Context, _a1 uint64) (*flow.Block, error) {
 	ret := _m.Called(_a0, _a1)

--- a/gateway/mocks/gateway_mock.go
+++ b/gateway/mocks/gateway_mock.go
@@ -30,6 +30,7 @@ import (
 
 const (
 	GetAccountFunc                       = "GetAccount"
+	GetAccountAtBlockHeightFunc          = "GetAccountAtBlockHeight"
 	SendSignedTransactionFunc            = "SendSignedTransaction"
 	GetCollectionFunc                    = "GetCollection"
 	GetTransactionResultFunc             = "GetTransactionResult"
@@ -49,6 +50,7 @@ type TestGateway struct {
 	Mock                             *Gateway
 	SendSignedTransaction            *mock.Call
 	GetAccount                       *mock.Call
+	GetAccountAtBlockHeight          *mock.Call
 	GetCollection                    *mock.Call
 	GetTransactionResult             *mock.Call
 	GetEvents                        *mock.Call
@@ -82,6 +84,12 @@ func DefaultMockGateway() *TestGateway {
 			GetAccountFunc,
 			ctxMock,
 			mock.AnythingOfType("flow.Address"),
+		),
+		GetAccountAtBlockHeight: m.On(
+			GetAccountAtBlockHeightFunc,
+			ctxMock,
+			mock.AnythingOfType("flow.Address"),
+			mock.AnythingOfType("uint64"),
 		),
 		GetCollection: m.On(
 			GetCollectionFunc,
@@ -146,7 +154,16 @@ func DefaultMockGateway() *TestGateway {
 
 	t.GetAccount.Run(func(args mock.Arguments) {
 		addr := args.Get(1).(flow.Address)
-		t.GetAccount.Return(tests.NewAccountWithAddress(addr.String()), nil)
+		acc := tests.NewAccountWithAddress(addr.String())
+		t.GetAccount.Return(acc, nil)
+	})
+
+	t.GetAccountAtBlockHeight.Run(func(args mock.Arguments) {
+		addr := args.Get(1).(flow.Address)
+		// Return the same account structure as GetAccount for consistency
+		// If the test needs specific contracts, it should override this mock
+		acc := tests.NewAccountWithAddress(addr.String())
+		t.GetAccountAtBlockHeight.Return(acc, nil)
 	})
 
 	t.ExecuteScript.Run(func(args mock.Arguments) {

--- a/schema.json
+++ b/schema.json
@@ -240,6 +240,9 @@
         "hash": {
           "type": "string"
         },
+        "block_height": {
+          "type": "integer"
+        },
         "aliases": {
           "patternProperties": {
             ".*": {


### PR DESCRIPTION
Closes #188 

 - Add `GetAccountByBlockHeight`
 - Add block_height pins to dependencies

Related https://github.com/onflow/flow-cli/pull/2246