### PR TITLE
Fix spinner race condition

### DIFF
--- a/output/spinner.go
+++ b/output/spinner.go
@@ -20,12 +20,14 @@ package output
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/gosuri/uilive"
 )
 
 var spinnerCharset = []rune{'⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'}
+var mu = sync.Mutex{}
 
 type Spinner struct {
 	prefix string
@@ -46,7 +48,10 @@ func (s *Spinner) Start() {
 }
 
 func (s *Spinner) run() {
+	mu.Lock()
+	// writes to global variable, need a global lock to avoid race conditions
 	writer := uilive.New()
+	mu.Unlock()
 
 	ticker := time.NewTicker(100 * time.Millisecond)
 
@@ -56,7 +61,10 @@ func (s *Spinner) run() {
 		select {
 		case <-s.done:
 			_, _ = fmt.Fprintf(writer, "\r")
+			mu.Lock()
+			// writes to global variable, need a global lock to avoid race conditions
 			_ = writer.Flush()
+			mu.Unlock()
 			close(s.done)
 			return
 		case <-ticker.C:


### PR DESCRIPTION
`uilive.New()` and `writer.Flush()` both write to a global variable inside the `uilive` package, which causes data races when multiple spinners run concurrently. This adds a package-level `sync.Mutex` to serialize those two critical sections. The ticker loop itself is unaffected since it only reads from the writer after initialization.
